### PR TITLE
yocto-based-OS-image: Modify to match fleet versioning

### DIFF
--- a/lib/repo-type-mappings/yocto-based-OS-image/dependencies.yml
+++ b/lib/repo-type-mappings/yocto-based-OS-image/dependencies.yml
@@ -1,3 +1,4 @@
 - name: 'lodash'
 - name: 'balena-semver'
 - name: 'shelljs'
+- name: 'js-yaml'

--- a/lib/repo-type-mappings/yocto-based-OS-image/versionist.conf.js
+++ b/lib/repo-type-mappings/yocto-based-OS-image/versionist.conf.js
@@ -5,6 +5,7 @@ const fs = require('fs')
 const path = require('path')
 const semver = require('balena-semver')
 const shell = require('shelljs')
+const yaml = require('js-yaml');
 
 const isESR = (version) => {
   return /^\d{4}\.(01|04|07|10)\.\d+$/.test(version)
@@ -66,6 +67,21 @@ module.exports = {
       return  `${parsedCurrentVersion.version}+rev${revision + 1}`
     }
     return `${parsedCurrentVersion.version}`
+  },
+  updateContract: (cwd, version, callback) => {
+      if (/^\d+\.\d+\.\d+$/.test(version) == false &&
+          /^\d+\.\d+\.\d+\+rev\d+$/.test(version) == false) {
+        return callback(new Error(`Invalid version ${version}`));
+      }
+
+      const contract = path.join(cwd, 'balena.yml');
+      if (!fs.existsSync(contract)) {
+        return callback(null, version);
+      }
+
+      const content = yaml.load(fs.readFileSync(contract, 'utf8'));
+      content.version = version;
+      fs.writeFile(contract, yaml.dump(content), callback);
   },
   getCurrentBaseVersion: getMetaResinFromSubmodule,
   updateVersion: 'update-version-file',

--- a/lib/repo-type-mappings/yocto-based-OS-image/versionist.conf.js
+++ b/lib/repo-type-mappings/yocto-based-OS-image/versionist.conf.js
@@ -6,7 +6,16 @@ const path = require('path')
 const semver = require('balena-semver')
 const shell = require('shelljs')
 
+const isESR = (version) => {
+  return /^\d{4}\.(01|04|07|10)\.\d+$/.test(version)
+}
+
 const getMetaResinFromSubmodule = (documentedVersions, history, callback) => {
+  const latestDocumented = _.trim(_.last(documentedVersions.sort(semver.compare)))
+  // ESR releases do not update meta-balena versions
+  if (isESR(latestDocumented)) {
+    return callback(null, latestDocumented)
+  }
   // This is a hack because git does not update all the relevant files when moving a
   // submodule. Because of this, older repos will still have references to meta-resin
   // and new ones will refer to meta-balena
@@ -17,19 +26,15 @@ const getMetaResinFromSubmodule = (documentedVersions, history, callback) => {
     if (code != 0) {
       return callback(new Error(`Could not find ${metaName} submodule`))
     }
-    const match = stdout.replace(/\s/g,'').replace(/^v/g, '')
-
-    if (!match) {
+    const metaVersion = stdout.replace(/\s/g,'').replace(/^v/g, '')
+    if (!metaVersion) {
       return callback(new Error(`Could not determine ${metaName} version from version ${stdout}`))
     }
 
-    const metaVersion = `${match}+rev0`
-    const latestDocumented = _.trim(_.last(documentedVersions.sort(semver.compare)))
-
+    const latestDocumentedRevision = latestDocumented.includes('rev')? latestDocumented : `${semver.parse(latestDocumented).version}+rev0`
     // semver.gt will ignore the revision numbers but still compare the version
     // If metaVersion <= latestDocumented then the latestDocumented version is a revision of the current metaVersion
-    const latestVersion = semver.gt(metaVersion, latestDocumented) ? metaVersion : latestDocumented
-
+    const latestVersion = semver.gt(metaVersion, latestDocumentedRevision) ? metaVersion : latestDocumentedRevision
     return callback(null, latestVersion)
   })
 }
@@ -49,11 +54,18 @@ module.exports = {
     return 'patch'
   },
   incrementVersion: (currentVersion, incrementLevel) => {
-    const revision = Number(currentVersion[currentVersion.length - 1])
-    if (!_.isFinite(revision)) {
-      throw new Error(`Could not extract revision number from ${currentVersion}`)
+    if (isESR(currentVersion)) {
+      return semver.inc(currentVersion, 'patch')
     }
-    return currentVersion.slice(0, currentVersion.length - 1) + (revision + 1)
+    const parsedCurrentVersion = semver.parse(currentVersion)
+    if ( parsedCurrentVersion.build ) {
+      let revision = Number(String(parsedCurrentVersion.build).split('rev').pop())
+      if (!_.isFinite(revision)) {
+        throw new Error(`Could not extract revision number from ${currentVersion}`)
+      }
+      return  `${parsedCurrentVersion.version}+rev${revision + 1}`
+    }
+    return `${parsedCurrentVersion.version}`
   },
   getCurrentBaseVersion: getMetaResinFromSubmodule,
   updateVersion: 'update-version-file',


### PR DESCRIPTION
When releasing into a fleet a version specified in a contract,
the initial commit is M.m.p (+rev0 is omitted) and subsequent commits are of
the form M.m.p+revN where N starts at 1, as long as the contract version
remains the same.

This change uses the same convention for OS repositories so that the
commit tag and the fleet hostapp releases match.

Change-type: patch
Signed-off-by: Alex Gonzalez <alexg@balena.io>