### PR TITLE
Revert "Allow revisions of 2 or more digits for yocto-based-OS-image"

### DIFF
--- a/lib/repo-type-mappings/yocto-based-OS-image/versionist.conf.js
+++ b/lib/repo-type-mappings/yocto-based-OS-image/versionist.conf.js
@@ -49,7 +49,7 @@ module.exports = {
     return 'patch'
   },
   incrementVersion: (currentVersion, incrementLevel) => {
-    const revision = Number(currentVersion.split('+rev')[1])
+    const revision = Number(currentVersion[currentVersion.length - 1])
     if (!_.isFinite(revision)) {
       throw new Error(`Could not extract revision number from ${currentVersion}`)
     }


### PR DESCRIPTION
This reverts commit 5a213ff4d38fc367f215d6a1929c4ce6b5ae2a9b.

ESR releases with format YYYY.QQ.n do not have a `+rev` suffix and this
commit breaks the increment for them.

Change-type: patch