### PR TITLE
Parse yocto revisions of more than one digit

### DIFF
--- a/lib/repo-type-mappings/yocto-based-OS-image/versionist.conf.js
+++ b/lib/repo-type-mappings/yocto-based-OS-image/versionist.conf.js
@@ -49,7 +49,7 @@ module.exports = {
     return 'patch'
   },
   incrementVersion: (currentVersion, incrementLevel) => {
-    const revision = Number(currentVersion[currentVersion.length - 1])
+    const revision = Number(currentVersion.split(/(rev|\.)/).pop());
     if (!_.isFinite(revision)) {
       throw new Error(`Could not extract revision number from ${currentVersion}`)
     }


### PR DESCRIPTION
Supports both yocto revisions and ESR releases.

Change-type: patch
Signed-off-by: Kyle Harding <kyle@balena.io>
Resolves: https://github.com/product-os/balena-versionist/issues/64
See: https://github.com/product-os/balena-versionist/pull/63