### PR TITLE
yocto-based-OS-image: Fix empty check on object type

### DIFF
--- a/lib/repo-type-mappings/yocto-based-OS-image/versionist.conf.js
+++ b/lib/repo-type-mappings/yocto-based-OS-image/versionist.conf.js
@@ -59,7 +59,7 @@ module.exports = {
       return semver.inc(currentVersion, 'patch')
     }
     const parsedCurrentVersion = semver.parse(currentVersion)
-    if ( parsedCurrentVersion.build ) {
+    if ( ! _.isEmpty(parsedCurrentVersion.build) ) {
       let revision = Number(String(parsedCurrentVersion.build).split('rev').pop())
       if (!_.isFinite(revision)) {
         throw new Error(`Could not extract revision number from ${currentVersion}`)


### PR DESCRIPTION
As parsedCurrentVersion.build is of object type the current check is
always true even when the object is empty.

Change-type: patch
Signed-off-by: Alex Gonzalez <alexg@balena.io>