### PR TITLE
Fix custom config not being used

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -67,7 +67,7 @@ const injectConfig = (path) => {
       if (config.upstream) {
         config.upstream = extractUpstreamInfo(config.upstream)
       }
-      return Promise.resolve(configOverrides[normalisedType].getConfig(config))
+      return Promise.resolve(configOverrides[normalisedType].getConfig(config, path))
       .tap((result) => {
         log('Installing injected dependencies')
         log(result.dependencies)

--- a/lib/repo-type-mappings/index.js
+++ b/lib/repo-type-mappings/index.js
@@ -8,6 +8,8 @@ const _ = require('lodash')
 const YAML = require('js-yaml')
 const mustache = require('mustache')
 
+const CONF_FILENAME = 'versionist.conf.js'
+
 const isDirectory = (source) => lstatSync(source).isDirectory()
 const getDirectories = (source) => {
   return _(readdirSync(source))
@@ -19,15 +21,22 @@ const getDirectories = (source) => {
 const mappings = getDirectories(__dirname)
 
 const exportedMappings = _.reduce(mappings, (exportedMappings, dirName) => {
-  const configFile = readFileSync(join(dirName, 'versionist.conf.js'), 'utf8')
   const dependencies = YAML.safeLoad(readFileSync(join(dirName, 'dependencies.yml'), 'utf8'))
-
   const type = basename(dirName)
   exportedMappings[type] = {}
-  exportedMappings[type].getConfig = (options) => {
+  exportedMappings[type].getConfig = (options, path) => {
+
+    let configuration = '';
+    try {
+      configuration = readFileSync(join(path, CONF_FILENAME), 'utf8');
+    } catch(err) {
+      const defaultConf = readFileSync(join(dirName, CONF_FILENAME), 'utf8')
+      configuration = mustache.render(defaultConf, options)
+    }
+
     return {
-      configuration: mustache.render(configFile, options),
-      dependencies: dependencies
+      configuration,
+      dependencies,
     }
   }
   return exportedMappings


### PR DESCRIPTION
`versionist.conf.js` in root directory was not being respected by `balena-versionist`.

Change-type: patch
Signed-off-by: Stathis Moraitidis <stathis@balena.io>