### PR TITLE
Prevent pattern HTML-escaping

### DIFF
--- a/lib/repo-type-mappings/balena-engine/versionist.conf.js
+++ b/lib/repo-type-mappings/balena-engine/versionist.conf.js
@@ -43,7 +43,7 @@ module.exports = {
     upstream: [
       {{#upstream}}
       {
-        pattern: '{{pattern}}',
+        pattern: '{{{pattern}}}',
         repo: '{{repo}}',
         owner: '{{owner}}',
         ref: '{{ref}}'

--- a/lib/repo-type-mappings/composite/versionist.conf.js
+++ b/lib/repo-type-mappings/composite/versionist.conf.js
@@ -39,7 +39,7 @@ module.exports = {
     upstream: [
       {{#upstream}}
       {
-        pattern: '{{pattern}}',
+        pattern: '{{{pattern}}}',
         repo: '{{repo}}',
         owner: '{{owner}}',
         ref: '{{ref}}'

--- a/lib/repo-type-mappings/docker/versionist.conf.js
+++ b/lib/repo-type-mappings/docker/versionist.conf.js
@@ -8,7 +8,7 @@ module.exports = {
     upstream: [
       {{#upstream}}
       {
-        pattern: '{{pattern}}',
+        pattern: '{{{pattern}}}',
         repo: '{{repo}}',
         owner: '{{owner}}',
         ref: '{{ref}}'

--- a/lib/repo-type-mappings/electron/versionist.conf.js
+++ b/lib/repo-type-mappings/electron/versionist.conf.js
@@ -29,7 +29,7 @@ module.exports = {
     upstream: [
       {{#upstream}}
       {
-        pattern: '{{pattern}}',
+        pattern: '{{{pattern}}}',
         repo: '{{repo}}',
         owner: '{{owner}}',
         ref: '{{ref}}'

--- a/lib/repo-type-mappings/generic/versionist.conf.js
+++ b/lib/repo-type-mappings/generic/versionist.conf.js
@@ -11,7 +11,7 @@ module.exports = {
     upstream: [
       {{#upstream}}
       {
-        pattern: '{{pattern}}',
+        pattern: '{{{pattern}}}',
         repo: '{{repo}}',
         owner: '{{owner}}',
         ref: '{{ref}}'

--- a/lib/repo-type-mappings/node/versionist.conf.js
+++ b/lib/repo-type-mappings/node/versionist.conf.js
@@ -7,7 +7,7 @@ module.exports = {
     upstream: [
       {{#upstream}}
       {
-        pattern: '{{pattern}}',
+        pattern: '{{{pattern}}}',
         repo: '{{repo}}',
         owner: '{{owner}}',
         ref: '{{ref}}'

--- a/lib/repo-type-mappings/public-docs/versionist.conf.js
+++ b/lib/repo-type-mappings/public-docs/versionist.conf.js
@@ -14,7 +14,7 @@ module.exports = {
     upstream: [
       {{#upstream}}
       {
-        pattern: '{{pattern}}',
+        pattern: '{{{pattern}}}',
         repo: '{{repo}}',
         owner: '{{owner}}',
         ref: '{{ref}}'

--- a/lib/repo-type-mappings/rust-module/versionist.conf.js
+++ b/lib/repo-type-mappings/rust-module/versionist.conf.js
@@ -24,7 +24,7 @@ module.exports = {
     upstream: [
       {{#upstream}}
       {
-        pattern: '{{pattern}}',
+        pattern: '{{{pattern}}}',
         repo: '{{repo}}',
         owner: '{{owner}}',
         ref: '{{ref}}'

--- a/lib/repo-type-mappings/yocto-based-OS-image/versionist.conf.js
+++ b/lib/repo-type-mappings/yocto-based-OS-image/versionist.conf.js
@@ -91,7 +91,7 @@ module.exports = {
     upstream: [
       {{#upstream}}
       {
-        pattern: '{{pattern}}',
+        pattern: '{{{pattern}}}',
         repo: '{{repo}}',
         owner: '{{owner}}',
         ref: '{{ref}}'

--- a/lib/repo-type-mappings/yocto-layer/versionist.conf.js
+++ b/lib/repo-type-mappings/yocto-layer/versionist.conf.js
@@ -40,7 +40,7 @@ module.exports = {
     upstream: [
       {{#upstream}}
       {
-        pattern: '{{pattern}}',
+        pattern: '{{{pattern}}}',
         repo: '{{repo}}',
         owner: '{{owner}}',
         ref: '{{ref}}'


### PR DESCRIPTION
Prevent mustache HTML-escaping the patterns, so that they can be properly matched in the regex. Previously, patterns like `@balena/abstract-sql-compiler` would be rendered as `@balena&#x2F;abstract-sql-compiler` by mustache. Subsequently the regex that identifies whether a nested changelog needs to be attached, by matching the pattern against the commit body, would fail.

Change-type: patch
Signed-off-by: Stathis Moraitidis <stathis@balena.io>