### PR TITLE
yocto-based-OS-image: Support both legacy and semver compatible ESR versions

### DIFF
--- a/lib/repo-type-mappings/yocto-based-OS-image/versionist.conf.js
+++ b/lib/repo-type-mappings/yocto-based-OS-image/versionist.conf.js
@@ -8,7 +8,7 @@ const shell = require('shelljs')
 const yaml = require('js-yaml');
 
 const isESR = (version) => {
-  return /^\d{4}\.(01|04|07|10)\.\d+$/.test(version)
+  return /^\d{4}\.(01|1|04|4|07|7|10)\.\d+$/.test(version)
 }
 
 const getMetaResinFromSubmodule = (documentedVersions, history, callback) => {
@@ -56,7 +56,8 @@ module.exports = {
   },
   incrementVersion: (currentVersion, incrementLevel) => {
     if (isESR(currentVersion)) {
-      return semver.inc(currentVersion, 'patch')
+      const [majorVersion, minorVersion, patchVersion] = currentVersion.split('.', 3);
+      return `${majorVersion}.${minorVersion}.${Number(patchVersion) + 1}`
     }
     const parsedCurrentVersion = semver.parse(currentVersion)
     if ( ! _.isEmpty(parsedCurrentVersion.build) ) {


### PR DESCRIPTION
The `balena-semver` library modifies `semver.valid()` to accept ESR versions like `2021.07.1`, but does not modify the `semver.inc()` accordingly, so incrementing `2021.07.1` provides `2021.7.2`, breaking the versioning format.
Given that ESR versioning of the form `2021.07` has now been discontinued in favour of semver compatible formats (2021.7), let's handle the legacy format in `balena-versionist` instead of touching `balena-semver`.

The alternative is modifying `balena-semver` to increment accordingly, but the change is less controlled as I don't know other places that use `balena-semver`.

In any case, the ESR version check would need to be modified anyway.