### PR TITLE
Use '.cjs' in filename to identify the config as a CommonJS module

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -13,6 +13,8 @@ const parseGithubURL = require('parse-github-url')
 const configOverrides = require('./repo-type-mappings')
 const remapTypes = require('./remap.js')
 let LOG_LEVEL = 'verbose'
+// Use 'cjs' to identify the config as CommonJS when running for an ES6 module
+const CONFIG_FILENAME = 'versionist.tmp.cjs'
 
 const log = (l) => {
   if (LOG_LEVEL !== 'silent') {
@@ -80,7 +82,7 @@ const injectConfig = (path) => {
         }
       }).then((result) => {
         log('Writing temp configuration')
-        return writeFileAsync(join(path, 'versionist.tmp.js'), result.configuration)
+        return writeFileAsync(join(path, CONFIG_FILENAME), result.configuration)
       }).then(() => {
         return true
       })
@@ -110,7 +112,7 @@ module.exports.runBalenaVersionist = (path, options = {}) => {
     const extraOpts = buildVersionistOptions(options)
     let config = ''
     if (injectedConfig) {
-      config += '--config=versionist.tmp.js'
+      config += `--config=${CONFIG_FILENAME}`
     }
     log('Versioning')
     return execAsync(`versionist ${config} ${extraOpts}`, { cwd: path })
@@ -125,7 +127,7 @@ module.exports.runBalenaVersionist = (path, options = {}) => {
     }).finally(() => {
       if (injectedConfig) {
         log('Deleting temp configuration')
-        return unlinkAsync(join(path, 'versionist.tmp.js'))
+        return unlinkAsync(join(path, CONFIG_FILENAME))
       }
     })
   })


### PR DESCRIPTION
Uses `versionist.tmp.cjs` as the config file name. Required when module under test is an ES6 modules identified by "type":"module" in its `package.json`. Otherwise JS considers the versionist config as an ES6 module, which it is not.

Tested with:

* JS, `repo.yml` has type: node; has ES6 module identified in `package.json`
* JS, `repo.yml' has type: node; has Common JS module
* JS, `repo.yml` has type: generic
* TypeScript, `repo.yml` has type: electron
* Python, `repo.yml` has type: generic

Fixes #79