### PR TITLE
Use `spawnAsync` instead of `execAsync` to avoid the shell entirely

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -6,7 +6,7 @@ const {
   accessAsync,
   unlinkAsync
 } = Promise.promisifyAll(require('fs'))
-const { execAsync } = Promise.promisifyAll(require('child_process'))
+const { spawnAsync } = Promise.promisifyAll(require('child_process'))
 const { join } = require('path')
 const YAML = require('js-yaml')
 const parseGithubURL = require('parse-github-url')
@@ -47,7 +47,7 @@ const installConfigDependencies = (path) => {
   return accessAsync(join(path, 'versionist.conf.js'))
   .then(() => {
     log('Installing dev dependencies')
-    return execAsync(`npm install --only=dev`, { cwd: path })
+    return spawnAsync('npm', ['install', '--only=dev'], { cwd: path })
     .return(false)
   }).catch((err) => {
     // If no configuration file is found nothing needs to be done
@@ -74,11 +74,7 @@ const injectConfig = (path) => {
         log('Installing injected dependencies')
         log(result.dependencies)
         if (_.isArray(result.dependencies) && !_.isEmpty(result.dependencies)) {
-          const dependencies = _.reduce(result.dependencies, (soFar, dep) => {
-            soFar += `${dep.name} `
-            return soFar
-          }, '')
-          return execAsync(`npm install --no-save ${dependencies}`, { cwd: path })
+          return spawnAsync('npm', ['install', '--no-save', ...result.dependencies], { cwd: path })
         }
       }).then((result) => {
         log('Writing temp configuration')
@@ -110,16 +106,16 @@ module.exports.runBalenaVersionist = (path, options = {}) => {
     throw err
   }).then((injectedConfig) => {
     const extraOpts = buildVersionistOptions(options)
-    let config = ''
+    let config = []
     if (injectedConfig) {
-      config += `--config=${CONFIG_FILENAME}`
+      config = [`--config=${CONFIG_FILENAME}`]
     }
     log('Versioning')
-    return execAsync(`versionist ${config} ${extraOpts}`, { cwd: path })
+    return spawnAsync('versionist', [...config, ...extraOpts], { cwd: path })
     .then((stdout, stderr) => {
       logInDebug(`stdout: ${stdout}`)
       logInDebug(`stderr: ${stderr}`)
-      return execAsync(`versionist ${config} get version`, { cwd: path })
+      return spawnAsync('versionist', [...config, 'get', 'version'], { cwd: path })
       .then((stdout, stderr) => {
         log('Built version', stdout)
         return stdout.trim()
@@ -134,12 +130,12 @@ module.exports.runBalenaVersionist = (path, options = {}) => {
 }
 
 const buildVersionistOptions = (options) => {
-  let config = ''
+  let config = []
   if (options.version) {
-    config += `set ${options.version}`
+    config += ['set', options.version]
   }
   if (options.title) {
-    config += `-t ${JSON.stringify(options.title)}`
+    config += ['-t', JSON.stringify(options.title)]
   }
   return config
 }


### PR DESCRIPTION
Change-type: patch
Signed-off-by: Carol Schulze <carol@balena.io>