### PR TITLE
fix: Fix custom dependencies for config not being used

### DIFF
--- a/lib/repo-type-mappings/index.js
+++ b/lib/repo-type-mappings/index.js
@@ -21,17 +21,19 @@ const getDirectories = (source) => {
 const mappings = getDirectories(__dirname)
 
 const exportedMappings = _.reduce(mappings, (exportedMappings, dirName) => {
-  const dependencies = YAML.load(readFileSync(join(dirName, 'dependencies.yml'), 'utf8'))
   const type = basename(dirName)
   exportedMappings[type] = {}
   exportedMappings[type].getConfig = (options, path) => {
 
     let configuration = '';
+    let dependencies;
     try {
       configuration = readFileSync(join(path, CONF_FILENAME), 'utf8');
+      dependencies = YAML.load(readFileSync(join(path, 'dependencies.yml'), 'utf8'))
     } catch(err) {
       const defaultConf = readFileSync(join(dirName, CONF_FILENAME), 'utf8')
       configuration = mustache.render(defaultConf, options)
+      dependencies = YAML.load(readFileSync(join(dirName, 'dependencies.yml'), 'utf8'))
     }
 
     return {


### PR DESCRIPTION
`dependencies.yml` for `versionist.conf.js` in root directory was not being respected by balena-versionist.

The same thing was done for `versionist.conf.js` 2 years ago, see #70 #72

Change-type: patch